### PR TITLE
Refactor `reset()` to simplify memory cleanup

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -74,9 +74,9 @@ export class Winkblue {
       const rSet = this._internal_selector_mem[selector];
       for (const r of rSet) {
         r.mo.disconnect();
-        rSet.delete(r);
       }
     }
+    this._internal_selector_mem = Object.create(null);
   }
 }
 


### PR DESCRIPTION
- Refactor `reset()` to simplify memory cleanup by resetting `_internal_selector_mem` after disconnecting MutationObservers